### PR TITLE
Implement basic EEG recorder modules

### DIFF
--- a/pinguis/__init__.py
+++ b/pinguis/__init__.py
@@ -1,0 +1,3 @@
+"""Pinguis EEG recording utilities."""
+
+__all__ = ["serial_utils", "decoder", "writer", "recorder"]

--- a/pinguis/decoder.py
+++ b/pinguis/decoder.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import List
+
+BYTES_PER_SAMPLE = 3
+DEFAULT_SAMPLE_RATE = 256
+
+
+def _decode_24bit_le(value: bytes) -> int:
+    """Convert 3 little-endian bytes to a signed integer."""
+    if len(value) != 3:
+        raise ValueError("expected 3 bytes")
+    # Expand to 4 bytes for signed conversion
+    unsigned = int.from_bytes(value + (b"\x00" if value[2] < 0x80 else b"\xff"), "little", signed=True)
+    return unsigned
+
+
+def decode_frame(frame: bytes, num_channels: int) -> List[int]:
+    """Decode a single frame into integer samples."""
+    if len(frame) != num_channels * BYTES_PER_SAMPLE:
+        raise ValueError("frame size mismatch")
+    samples = []
+    for ch in range(num_channels):
+        start = ch * BYTES_PER_SAMPLE
+        sample_bytes = frame[start : start + BYTES_PER_SAMPLE]
+        samples.append(_decode_24bit_le(sample_bytes))
+    return samples
+

--- a/pinguis/recorder.py
+++ b/pinguis/recorder.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+import numpy as np
+
+from .serial_utils import list_serial_ports, open_serial_port
+from .decoder import BYTES_PER_SAMPLE, decode_frame, DEFAULT_SAMPLE_RATE
+from .writer import write_edf
+
+
+class EEGRecorder:
+    """Simple EEG recorder that reads from a serial port and writes EDF."""
+
+    def __init__(self, port: Optional[str] = None, sample_rate: int = DEFAULT_SAMPLE_RATE):
+        self.port_name = port
+        self.sample_rate = sample_rate
+        self.num_channels: Optional[int] = None
+        self._serial = None
+        self._buffer = bytearray()
+
+    def _detect_channels(self) -> Optional[int]:
+        size = len(self._buffer)
+        if size % 12 == 0:
+            return 4
+        if size % 6 == 0:
+            return 2
+        return None
+
+    def _read_samples(self, duration: float) -> list[list[int]]:
+        samples = []
+        frame_size = None if self.num_channels is None else self.num_channels * BYTES_PER_SAMPLE
+        end_time = time.time() + duration
+        while time.time() < end_time:
+            chunk = self._serial.read(64)
+            if not chunk:
+                continue
+            self._buffer.extend(chunk)
+            if self.num_channels is None:
+                self.num_channels = self._detect_channels()
+                if self.num_channels:
+                    frame_size = self.num_channels * BYTES_PER_SAMPLE
+            while frame_size and len(self._buffer) >= frame_size:
+                frame = bytes(self._buffer[:frame_size])
+                del self._buffer[:frame_size]
+                samples.append(decode_frame(frame, self.num_channels))
+        return samples
+
+    def record_to_file(self, output_file: str, duration: float = 10) -> None:
+        if self.port_name is None:
+            ports = list_serial_ports()
+            if not ports:
+                raise RuntimeError("No serial ports found")
+            self.port_name = ports[0]
+        with open_serial_port(self.port_name) as self._serial:
+            sample_list = self._read_samples(duration)
+        if not sample_list:
+            raise RuntimeError("No samples captured")
+        signals = []
+        for ch in range(self.num_channels):
+            signals.append(np.array([s[ch] for s in sample_list], dtype=np.int32))
+        write_edf(output_file, signals, self.sample_rate)
+
+
+def record(output_file: str, duration: float = 10, port: Optional[str] = None) -> None:
+    EEGRecorder(port=port).record_to_file(output_file, duration)

--- a/pinguis/serial_utils.py
+++ b/pinguis/serial_utils.py
@@ -1,0 +1,27 @@
+import re
+from typing import List
+
+try:
+    import serial
+    from serial.tools import list_ports
+except Exception:  # pragma: no cover - environment may not have pyserial
+    serial = None
+    list_ports = None
+
+
+def list_serial_ports() -> List[str]:
+    """Return a list of available serial port device names."""
+    if list_ports is None:
+        return []
+    ports = [p.device for p in list_ports.comports()]
+    # On macOS devices appear as /dev/tty.* or /dev/cu.*; filter accordingly
+    mac_pattern = re.compile(r"/dev/(tty|cu)\..*")
+    filtered = [p for p in ports if mac_pattern.match(p) or not p.startswith('/dev/')]
+    return filtered
+
+
+def open_serial_port(port: str, baudrate: int = 115200, timeout: float = 1.0):
+    """Open a serial port if pyserial is available."""
+    if serial is None:
+        raise RuntimeError("pyserial is required to open serial ports")
+    return serial.Serial(port=port, baudrate=baudrate, timeout=timeout)

--- a/pinguis/writer.py
+++ b/pinguis/writer.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import List
+
+import numpy as np
+
+try:
+    import pyedflib
+except Exception:  # pragma: no cover - pyedflib may not be present
+    pyedflib = None
+
+
+def write_edf(filename: str, signals: List[np.ndarray], sample_rate: int) -> None:
+    """Write EEG data to an EDF+ file."""
+    if pyedflib is None:
+        raise RuntimeError("pyedflib is required to write EDF files")
+    n_channels = len(signals)
+    with pyedflib.EdfWriter(
+        filename,
+        n_channels=n_channels,
+        file_type=pyedflib.FILETYPE_EDFPLUS,
+    ) as writer:
+        headers = []
+        for i in range(n_channels):
+            headers.append({
+                "label": f"Ch{i+1}",
+                "dimension": "uV",
+                "sample_rate": sample_rate,
+            })
+        writer.setSignalHeaders(headers)
+        writer.writeSamples(signals)

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -1,0 +1,16 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import pytest
+
+from pinguis.decoder import decode_frame, _decode_24bit_le
+
+
+def test_decode_24bit_le_positive():
+    assert _decode_24bit_le(b"\x00\x00\x00") == 0
+    assert _decode_24bit_le(b"\xff\x7f\x00") == 32767
+
+
+def test_decode_frame_two_channels():
+    data = b"\x01\x00\x00\x02\x00\x00"
+    assert decode_frame(data, 2) == [1, 2]
+

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -1,0 +1,8 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from pinguis.serial_utils import list_serial_ports
+
+
+def test_list_serial_ports_runs():
+    ports = list_serial_ports()
+    assert isinstance(ports, list)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,0 +1,21 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import os
+
+import pytest
+pytest.importorskip("numpy")
+import numpy as np
+
+from pinguis.writer import write_edf
+
+
+def test_write_edf_requires_pyedflib(tmp_path):
+    signals = [np.zeros(10, dtype=np.int32)]
+    out = tmp_path / "out.edf"
+    try:
+        write_edf(str(out), signals, 256)
+    except RuntimeError as e:
+        assert "pyedflib" in str(e)
+    else:
+        assert out.exists()
+        os.remove(out)


### PR DESCRIPTION
## Summary
- add serial utility helpers
- add frame decoder and EDF+ writer
- implement EEGRecorder for CLI use
- create initial unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ad4749de08324b016a2fe70a59c08