### PR TITLE
Implement microvolt scaling for EDF writer

### DIFF
--- a/pinguis/recorder.py
+++ b/pinguis/recorder.py
@@ -81,7 +81,7 @@ class EEGRecorder:
                 samples.append(decoded)
         return samples
 
-    def record_to_file(self, output_file: str, duration: float = 10) -> None:
+    def record_to_file(self, output_file: str, duration: float = 10, gain: float = 1.0) -> None:
         if self.port_name is None:
             ports = list_serial_ports()
             if not ports:
@@ -95,7 +95,7 @@ class EEGRecorder:
         signals = []
         for ch in range(self.num_channels):
             signals.append(np.array([s[ch] for s in sample_list], dtype=np.int32))
-        write_edf(output_file, signals, self.sample_rate)
+        write_edf(output_file, signals, self.sample_rate, gain=gain)
 
-def record(output_file: str, duration: float = 10, port: Optional[str] = None) -> None:
-    EEGRecorder(port=port).record_to_file(output_file, duration)
+def record(output_file: str, duration: float = 10, port: Optional[str] = None, gain: float = 1.0) -> None:
+    EEGRecorder(port=port).record_to_file(output_file, duration, gain=gain)

--- a/pinguis/writer.py
+++ b/pinguis/writer.py
@@ -10,8 +10,20 @@ except Exception:  # pragma: no cover - pyedflib may not be present
     pyedflib = None
 
 
-def write_edf(filename: str, signals: List[np.ndarray], sample_rate: int) -> None:
-    """Write EEG data to an EDF+ file."""
+def write_edf(filename: str, signals: List[np.ndarray], sample_rate: int, gain: float = 1.0) -> None:
+    """Write EEG data to an EDF+ file.
+
+    Parameters
+    ----------
+    filename:
+        Path of the EDF file to create.
+    signals:
+        List of 1-D numpy arrays containing raw 24-bit integer values.
+    sample_rate:
+        Sampling rate of the signals.
+    gain:
+        Conversion factor from raw integer values to microvolts.
+    """
     if pyedflib is None:
         raise RuntimeError("pyedflib is required to write EDF files")
     n_channels = len(signals)
@@ -21,11 +33,25 @@ def write_edf(filename: str, signals: List[np.ndarray], sample_rate: int) -> Non
         file_type=pyedflib.FILETYPE_EDFPLUS,
     ) as writer:
         headers = []
+
+        digital_min = -(2 ** 23)
+        digital_max = (2 ** 23) - 1
+        physical_min = digital_min * gain
+        physical_max = digital_max * gain
+
         for i in range(n_channels):
-            headers.append({
-                "label": f"Ch{i+1}",
-                "dimension": "uV",
-                "sample_frequency": sample_rate,
-            })
+            headers.append(
+                {
+                    "label": f"Ch{i+1}",
+                    "dimension": "uV",
+                    "sample_frequency": sample_rate,
+                    "digital_min": digital_min,
+                    "digital_max": digital_max,
+                    "physical_min": physical_min,
+                    "physical_max": physical_max,
+                }
+            )
         writer.setSignalHeaders(headers)
-        writer.writeSamples(signals)
+
+        phys_signals = [sig.astype(np.float64) * gain for sig in signals]
+        writer.writePhysicalSamples(phys_signals)


### PR DESCRIPTION
## Summary
- convert 24‑bit integer samples to microvolt range before writing
- expose gain parameters when recording and writing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae47659148324ade4beef70748b32